### PR TITLE
修复模板双大括号输出导致的语法错误 | Fix template brace rendering

### DIFF
--- a/kiro_gateway/pages.py
+++ b/kiro_gateway/pages.py
@@ -577,6 +577,9 @@ COMMON_HEAD = r'''
   </script>
 '''
 
+# 还原 COMMON_HEAD 中为兼容 f-string 而写入的双大括号，避免输出到页面后出现语法错误。
+COMMON_HEAD = COMMON_HEAD.replace("{{", "{").replace("}}", "}")
+
 COMMON_NAV = r'''
   <nav style="background: var(--bg-nav); border-bottom: 1px solid var(--border); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);" class="sticky top-0 z-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -837,6 +840,11 @@ COMMON_FOOTER = '''
     </div>
   </footer>
 '''
+
+# 还原 COMMON_NAV 中为兼容 f-string 而写入的双大括号，避免前端脚本语法错误。
+COMMON_NAV = COMMON_NAV.replace("{{", "{").replace("}}", "}")
+# 填充版本号占位符。
+COMMON_NAV = COMMON_NAV.replace("{APP_VERSION}", APP_VERSION)
 
 # 移除旧的 THEME_SCRIPT，已经集成到 COMMON_NAV 中
 


### PR DESCRIPTION
## 🎯 改动概述 | Changes Overview

本 PR 修复首页模板渲染中双大括号被原样输出导致的前端语法错误，并补齐版本号占位符显示。
This PR fixes frontend syntax errors caused by raw double-brace output in templates, and fills the version placeholder.

---

### 🐛 Bug 修复 | Bug Fixes

#### 1. 修复模板双大括号导致的 JS 语法错误
#### Fix JS syntax error caused by double braces in templates

**问题 | Problem**:
- 首页控制台报错 `Uncaught SyntaxError: Unexpected token '{'`
- Home page console error `Uncaught SyntaxError: Unexpected token '{'`

**根本原因 | Root Cause**:
- `COMMON_HEAD`/`COMMON_NAV` 中为兼容 f-string 写入的 `{{`/`}}` 被原样输出到页面，破坏 JS 语法
- `{{`/`}}` in `COMMON_HEAD`/`COMMON_NAV` were output verbatim, breaking JS syntax

**解决方案 | Solution**:
- 在模板渲染后统一还原双大括号为单大括号
- Normalize double braces back to single braces after template rendering

**文件 | Files**: `kiro_gateway/pages.py`

---

#### 2. 修复版本号占位符未替换
#### Fix unresolved version placeholder

**问题 | Problem**:
- 导航栏显示 `v{APP_VERSION}` 而非实际版本号
- Navbar showed `v{APP_VERSION}` instead of the real version

**根本原因 | Root Cause**:
- `COMMON_NAV` 非 f-string，版本号未被格式化
- `COMMON_NAV` is not an f-string, so the placeholder was never formatted

**解决方案 | Solution**:
- 额外替换 `{APP_VERSION}` 占位符为实际版本号
- Replace `{APP_VERSION}` placeholder with the actual version

**文件 | Files**: `kiro_gateway/pages.py`

---

## 🧪 测试 | Testing

- 未运行自动化测试（仅模板渲染修复）
- No automated tests run (template rendering fix only)

---

## 📊 包含的提交 | Commits Included

```
9b2e1c6 Fix template brace rendering
```

---

## 🔗 相关问题 | Related Issues

- 修复首页控制台语法错误
- Fixes home page console syntax error
