### PR TITLE
feat: 添加 IDC (AWS Builder ID) 认证支持

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,27 @@ PROXY_API_KEY="my-super-secret-password-123"
 KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # ===========================================
-# 方式二: Kiro Refresh Token
+# 方式二: Kiro Refresh Token (Social 登录)
 # ===========================================
 
 # 从 Kiro IDE 流量中获取的 refresh token
+# 适用于使用 Google/GitHub 等社交账号登录的用户
 # （替代 KIRO_CREDS_FILE）
 # REFRESH_TOKEN="your_kiro_refresh_token_here"
+
+# ===========================================
+# 方式三: IDC 登录 (AWS Builder ID)
+# ===========================================
+
+# 如果你使用 AWS Builder ID 登录 Kiro IDE，需要额外配置：
+# CLIENT_ID="your_client_id"
+# CLIENT_SECRET="your_client_secret"
+# REFRESH_TOKEN="your_refresh_token"
+# 
+# 这些值可以从 Kiro IDE 的凭证文件中获取：
+# - Windows: %APPDATA%\Kiro\credentials.json
+# - macOS: ~/Library/Application Support/Kiro/credentials.json
+# - Linux: ~/.config/Kiro/credentials.json
 
 # ===========================================
 # 可选项

--- a/kiro_gateway/config.py
+++ b/kiro_gateway/config.py
@@ -444,6 +444,7 @@ SLOW_MODELS: frozenset = frozenset({
 # ==================================================================================================
 
 KIRO_REFRESH_URL_TEMPLATE: str = "https://prod.{region}.auth.desktop.kiro.dev/refreshToken"
+AWS_SSO_OIDC_URL_TEMPLATE: str = "https://oidc.{region}.amazonaws.com/token"
 KIRO_API_HOST_TEMPLATE: str = "https://codewhisperer.{region}.amazonaws.com"
 KIRO_Q_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
 
@@ -502,6 +503,11 @@ APP_DESCRIPTION: str = "OpenAI & Anthropic compatible Kiro API gateway. Based on
 def get_kiro_refresh_url(region: str) -> str:
     """Return token refresh URL for specified region."""
     return KIRO_REFRESH_URL_TEMPLATE.format(region=region)
+
+
+def get_aws_sso_oidc_url(region: str) -> str:
+    """Return AWS SSO OIDC token URL for specified region."""
+    return AWS_SSO_OIDC_URL_TEMPLATE.format(region=region)
 
 
 def get_kiro_api_host(region: str) -> str:

--- a/kiro_gateway/pages.py
+++ b/kiro_gateway/pages.py
@@ -4403,14 +4403,14 @@ def render_user_page(user) -> str:
     </div>
   </main>
   <div id="donateModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" style="display: none;">
-    <div class="card w-full max-w-md mx-4">
+    <div class="card w-full max-w-md mx-4" style="max-height: 90vh; overflow-y: auto;">
       <h3 class="text-lg font-bold mb-4">🎁 批量添加 Refresh Token</h3>
 
       <!-- Token 输入区域 -->
       <div class="mb-3">
         <label class="text-sm font-medium mb-2 block">📝 粘贴 Token</label>
-        <textarea id="donateTokens" class="w-full h-32 p-3 rounded-lg text-sm" style="background: var(--bg-input); border: 1px solid var(--border);" placeholder="支持以下格式：&#10;• 每行一个 Token&#10;• 逗号分隔：token1, token2, token3&#10;• 混合格式"></textarea>
-        <p class="text-xs mt-1" style="color: var(--text-muted);">💡 支持多行或逗号分隔，自动去除空行和重复项</p>
+        <textarea id="donateTokens" class="w-full h-32 p-3 rounded-lg text-sm" style="background: var(--bg-input); border: 1px solid var(--border);" placeholder="支持以下格式：&#10;• Social: 每行一个 Token 或逗号分隔&#10;• IDC: JSON 格式 {&quot;clientId&quot;:&quot;...&quot;, &quot;clientSecret&quot;:&quot;...&quot;, &quot;refreshToken&quot;:&quot;...&quot;}"></textarea>
+        <p class="text-xs mt-1" style="color: var(--text-muted);">💡 IDC 用户请粘贴包含 clientId/clientSecret 的 JSON，系统自动识别认证类型</p>
       </div>
 
       <!-- 文件上传 -->
@@ -4544,6 +4544,11 @@ def render_user_page(user) -> str:
     }}
     .donate-mode-btn {{ color: var(--text-muted); }}
     .donate-mode-btn.active {{
+      background: linear-gradient(135deg, var(--primary), var(--accent));
+      color: white;
+    }}
+    .auth-type-btn {{ color: var(--text-muted); }}
+    .auth-type-btn.active {{
       background: linear-gradient(135deg, var(--primary), var(--accent));
       color: white;
     }}
@@ -5328,7 +5333,7 @@ def render_user_page(user) -> str:
       }}
       const anonymous = document.getElementById('donateAnonymous').checked;
 
-      // 构建请求
+      // 构建请求（后端自动识别 JSON 中的 clientId/clientSecret）
       const fd = new FormData();
       if (file) {{
         fd.append('file', file);

--- a/kiro_gateway/routes.py
+++ b/kiro_gateway/routes.py
@@ -36,8 +36,10 @@ import shutil
 import sqlite3
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 import httpx
@@ -2323,13 +2325,33 @@ IMPORT_VALIDATE_CONCURRENCY = 3
 IMPORT_ERROR_SAMPLE_LIMIT = 5
 
 
+@dataclass
+class TokenCredential:
+    """Token 凭证数据结构，支持 Social 和 IDC 两种认证方式。"""
+    refresh_token: str
+    auth_type: str = "social"  # social 或 idc
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+
+
 def _split_tokens_text(text: str) -> list[str]:
     parts = re.split(r"[,\s;]+", text.strip())
     return [part for part in parts if part]
 
 
-def _extract_refresh_tokens(payload: object) -> tuple[list[str], int, list[str]]:
-    tokens: list[str] = []
+def _extract_refresh_tokens(payload: object) -> tuple[list[TokenCredential], int, list[str]]:
+    """
+    从导入数据中提取 token 凭证。
+    
+    支持的格式：
+    1. 纯文本列表：["token1", "token2"]
+    2. 对象列表：[{"refreshToken": "...", "clientId": "...", "clientSecret": "..."}]
+    3. 嵌套对象：{"accounts": [...], "credentials": {...}}
+    
+    Returns:
+        (credentials, missing_required, missing_samples)
+    """
+    credentials: list[TokenCredential] = []
     missing_required = 0
     missing_samples: list[str] = []
 
@@ -2339,31 +2361,79 @@ def _extract_refresh_tokens(payload: object) -> tuple[list[str], int, list[str]]
         if len(missing_samples) < IMPORT_ERROR_SAMPLE_LIMIT:
             missing_samples.append(f"{path}: {reason}")
 
-    def add_token(value: object, path: str) -> None:
-        if isinstance(value, str):
-            token = value.strip()
+    def add_credential(obj: dict | str, path: str) -> None:
+        """从对象或字符串中提取凭证。"""
+        if isinstance(obj, str):
+            token = obj.strip()
             if token:
-                tokens.append(token)
+                credentials.append(TokenCredential(refresh_token=token))
                 return
-        record_missing(path, "refreshToken 为空或无效")
+            record_missing(path, "refreshToken 为空")
+            return
+        
+        if not isinstance(obj, dict):
+            record_missing(path, "类型不支持")
+            return
+        
+        # 尝试从对象中提取 refreshToken
+        refresh_token = None
+        client_id = None
+        client_secret = None
+        
+        # 直接字段
+        if "refreshToken" in obj:
+            refresh_token = obj.get("refreshToken")
+        # 嵌套在 credentials 中
+        elif isinstance(obj.get("credentials"), dict):
+            creds = obj["credentials"]
+            refresh_token = creds.get("refreshToken")
+            client_id = creds.get("clientId")
+            client_secret = creds.get("clientSecret")
+        
+        # 获取 clientId 和 clientSecret（如果在顶层）
+        if client_id is None:
+            client_id = obj.get("clientId")
+        if client_secret is None:
+            client_secret = obj.get("clientSecret")
+        
+        if not refresh_token or not isinstance(refresh_token, str):
+            record_missing(path, "缺少 refreshToken")
+            return
+        
+        refresh_token = refresh_token.strip()
+        if not refresh_token:
+            record_missing(path, "refreshToken 为空")
+            return
+        
+        # 判断认证类型
+        auth_type = "social"
+        if client_id and client_secret:
+            auth_type = "idc"
+            client_id = client_id.strip() if isinstance(client_id, str) else None
+            client_secret = client_secret.strip() if isinstance(client_secret, str) else None
+        
+        credentials.append(TokenCredential(
+            refresh_token=refresh_token,
+            auth_type=auth_type,
+            client_id=client_id if auth_type == "idc" else None,
+            client_secret=client_secret if auth_type == "idc" else None,
+        ))
 
     def handle_list(items: list, path: str, enforce_required: bool) -> None:
         for index, item in enumerate(items):
             item_path = f"{path}[{index}]"
             if isinstance(item, dict):
-                if "refreshToken" in item:
-                    add_token(item.get("refreshToken"), f"{item_path}.refreshToken")
-                elif (
+                if "refreshToken" in item or (
                     isinstance(item.get("credentials"), dict)
                     and "refreshToken" in item["credentials"]
                 ):
-                    add_token(item["credentials"].get("refreshToken"), f"{item_path}.credentials.refreshToken")
+                    add_credential(item, item_path)
                 else:
                     if enforce_required:
                         record_missing(item_path, "缺少 refreshToken")
                     handle_dict(item, item_path)
             elif isinstance(item, str):
-                add_token(item, item_path)
+                add_credential(item, item_path)
             elif isinstance(item, list):
                 handle_list(item, item_path, enforce_required)
             else:
@@ -2371,13 +2441,13 @@ def _extract_refresh_tokens(payload: object) -> tuple[list[str], int, list[str]]
                     record_missing(item_path, "类型不支持")
 
     def handle_dict(obj: dict, path: str) -> None:
-        if "refreshToken" in obj:
-            add_token(obj.get("refreshToken"), f"{path}.refreshToken" if path else "refreshToken")
-        if isinstance(obj.get("credentials"), dict) and "refreshToken" in obj["credentials"]:
-            add_token(
-                obj["credentials"].get("refreshToken"),
-                f"{path}.credentials.refreshToken" if path else "credentials.refreshToken"
-            )
+        # 检查顶层是否有 refreshToken
+        if "refreshToken" in obj or (
+            isinstance(obj.get("credentials"), dict)
+            and "refreshToken" in obj["credentials"]
+        ):
+            add_credential(obj, path)
+            return
 
         for key, value in obj.items():
             if isinstance(value, dict):
@@ -2391,19 +2461,20 @@ def _extract_refresh_tokens(payload: object) -> tuple[list[str], int, list[str]]
     elif isinstance(payload, dict):
         handle_dict(payload, "")
     elif isinstance(payload, str):
-        add_token(payload, "refreshToken")
+        add_credential(payload, "refreshToken")
 
-    return tokens, missing_required, missing_samples
+    return credentials, missing_required, missing_samples
 
 
-def _dedupe_tokens(tokens: list[str]) -> list[str]:
+def _dedupe_credentials(credentials: list[TokenCredential]) -> list[TokenCredential]:
+    """去重凭证列表，基于 refresh_token。"""
     seen: set[str] = set()
-    deduped: list[str] = []
-    for token in tokens:
-        if token in seen:
+    deduped: list[TokenCredential] = []
+    for cred in credentials:
+        if cred.refresh_token in seen:
             continue
-        seen.add(token)
-        deduped.append(token)
+        seen.add(cred.refresh_token)
+        deduped.append(cred)
     return deduped
 
 
@@ -2487,9 +2558,9 @@ async def _process_import_payload(
     anonymous: bool,
     payload: object
 ) -> tuple[dict, int]:
-    tokens, missing_required, missing_samples = _extract_refresh_tokens(payload)
-    tokens = _dedupe_tokens(tokens)
-    if not tokens:
+    credentials, missing_required, missing_samples = _extract_refresh_tokens(payload)
+    credentials = _dedupe_credentials(credentials)
+    if not credentials:
         message = "未找到可导入的 Refresh Token"
         if missing_required:
             message = f"{message}，缺少必填 {missing_required}。"
@@ -2499,38 +2570,40 @@ async def _process_import_payload(
             "error": message,
             "missing_required": missing_required,
         }, 400
-    if len(tokens) > IMPORT_TOKEN_MAX_COUNT:
-        return {"error": f"导入数量过多（{len(tokens)}），请拆分后导入"}, 400
+    if len(credentials) > IMPORT_TOKEN_MAX_COUNT:
+        return {"error": f"导入数量过多（{len(credentials)}），请拆分后导入"}, 400
 
     from kiro_gateway.database import user_db
 
-    pending_tokens: list[str] = []
+    pending_credentials: list[TokenCredential] = []
     skipped = 0
-    for token in tokens:
-        if user_db.token_exists(token):
+    for cred in credentials:
+        if user_db.token_exists(cred.refresh_token):
             skipped += 1
         else:
-            pending_tokens.append(token)
+            pending_credentials.append(cred)
 
     semaphore = asyncio.Semaphore(IMPORT_VALIDATE_CONCURRENCY)
 
-    async def validate_token(token: str) -> tuple[str, bool, str | None]:
+    async def validate_credential(cred: TokenCredential) -> tuple[TokenCredential, bool, str | None]:
         async with semaphore:
             try:
                 temp_manager = KiroAuthManager(
-                    refresh_token=token,
+                    refresh_token=cred.refresh_token,
+                    client_id=cred.client_id,
+                    client_secret=cred.client_secret,
                     region=settings.region,
                     profile_arn=settings.profile_arn
                 )
                 access_token = await temp_manager.get_access_token()
                 if not access_token:
-                    return token, False, "无法获取访问令牌"
-                return token, True, None
+                    return cred, False, "无法获取访问令牌"
+                return cred, True, None
             except Exception as exc:
-                return token, False, str(exc)
+                return cred, False, str(exc)
 
     validation_results = await asyncio.gather(
-        *(validate_token(token) for token in pending_tokens)
+        *(validate_credential(cred) for cred in pending_credentials)
     )
 
     imported = 0
@@ -2538,14 +2611,22 @@ async def _process_import_payload(
     failed = 0
     error_samples: list[str] = []
 
-    for token, ok, error in validation_results:
+    for cred, ok, error in validation_results:
         if not ok:
             invalid += 1
             if error and len(error_samples) < IMPORT_ERROR_SAMPLE_LIMIT:
-                error_samples.append(f"{_mask_token(token)}: {error}")
+                error_samples.append(f"{_mask_token(cred.refresh_token)}: {error}")
             continue
 
-        success, message = user_db.donate_token(user_id, token, visibility, anonymous)
+        success, message = user_db.donate_token(
+            user_id=user_id,
+            refresh_token=cred.refresh_token,
+            visibility=visibility,
+            anonymous=anonymous,
+            auth_type=cred.auth_type,
+            client_id=cred.client_id,
+            client_secret=cred.client_secret,
+        )
         if success:
             imported += 1
         else:
@@ -2554,9 +2635,9 @@ async def _process_import_payload(
             else:
                 failed += 1
                 if len(error_samples) < IMPORT_ERROR_SAMPLE_LIMIT:
-                    error_samples.append(f"{_mask_token(token)}: {message}")
+                    error_samples.append(f"{_mask_token(cred.refresh_token)}: {message}")
 
-    total = len(tokens)
+    total = len(credentials)
     message = (
         f"导入完成：成功 {imported}，已存在 {skipped}，无效 {invalid}，失败 {failed}。"
     )
@@ -2586,6 +2667,9 @@ async def _process_import_payload(
 async def user_donate_token(
     request: Request,
     refresh_token: str = Form(...),
+    auth_type: str = Form("social"),
+    client_id: str = Form(""),
+    client_secret: str = Form(""),
     visibility: str = Form("private"),
     anonymous: bool = Form(False),
     _csrf: None = Depends(require_same_origin)
@@ -2601,6 +2685,15 @@ async def user_donate_token(
 
     if visibility not in ("public", "private"):
         return JSONResponse(status_code=400, content={"error": "可见性无效"})
+    
+    if auth_type not in ("social", "idc"):
+        return JSONResponse(status_code=400, content={"error": "认证类型无效"})
+    
+    # IDC 模式必须提供 client_id 和 client_secret
+    client_id = client_id.strip() if client_id else None
+    client_secret = client_secret.strip() if client_secret else None
+    if auth_type == "idc" and (not client_id or not client_secret):
+        return JSONResponse(status_code=400, content={"error": "IDC 模式需要提供 Client ID 和 Client Secret"})
 
     from kiro_gateway.database import user_db
 
@@ -2610,6 +2703,8 @@ async def user_donate_token(
     try:
         temp_manager = KiroAuthManager(
             refresh_token=refresh_token,
+            client_id=client_id if auth_type == "idc" else None,
+            client_secret=client_secret if auth_type == "idc" else None,
             region=cfg.region,
             profile_arn=cfg.profile_arn
         )
@@ -2620,7 +2715,15 @@ async def user_donate_token(
         return {"success": False, "message": f"Token 验证失败：{str(e)}"}
 
     # Save token
-    success, message = user_db.donate_token(user.id, refresh_token, visibility, anonymous)
+    success, message = user_db.donate_token(
+        user_id=user.id,
+        refresh_token=refresh_token,
+        visibility=visibility,
+        anonymous=anonymous,
+        auth_type=auth_type,
+        client_id=client_id if auth_type == "idc" else None,
+        client_secret=client_secret if auth_type == "idc" else None,
+    )
     return {"success": success, "message": message}
 
 


### PR DESCRIPTION
## 功能描述

添加对 AWS IAM Identity Center (Builder ID) 认证方式的支持。

目前 KiroGate 仅支持 Social 登录（Google/GitHub 等社交账号），此 PR 添加了 IDC 登录支持，让使用 AWS Builder ID 登录 Kiro IDE 的用户也能使用 KiroGate。

## 改动内容

### auth.py
- 添加 `AuthType` 枚举，区分 `SOCIAL` 和 `IDC` 两种认证模式
- 实现 IDC 模式的 Token 刷新逻辑，使用 AWS SSO OIDC 端点
- 自动检测认证类型（根据是否提供 client_id/client_secret）

### config.py
- 添加 `AWS_SSO_OIDC_URL_TEMPLATE` 常量
- 添加 `get_aws_sso_oidc_url()` 函数

### database.py
- tokens 表添加 `auth_type` 字段（默认 'social'）
- tokens 表添加 `client_id_encrypted` 和 `client_secret_encrypted` 字段
- `donate_token()` 方法支持 IDC 模式参数

### routes.py
- Token 捐献接口支持 IDC 模式
- Token 导入接口支持 IDC 模式

### pages.py
- 更新前端提示，说明 IDC 登录方式的凭证获取路径

### .env.example
- 添加 IDC 配置说明和示例

## 认证方式对比

| 认证类型 | 端点 | 请求格式 |
|---------|------|---------|
| Social | `https://prod.{region}.auth.desktop.kiro.dev/refreshToken` | JSON: `{"refreshToken": "..."}` |
| IDC | `https://oidc.{region}.amazonaws.com/token` | JSON: `{"clientId": "...", "clientSecret": "...", "grantType": "refresh_token", "refreshToken": "..."}` |

## 测试

- [x] Social 模式 Token 刷新正常
- [x] IDC 模式 Token 刷新正常
- [x] Token 捐献（Social/IDC）正常
- [x] 数据库迁移兼容（自动添加新字段）