### PR TITLE
fix: health checker IDC support + compaction error fix + OpenAI error format + code optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 # Env
 .env
 .env.local
+kiro_creds.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,18 @@
 .DS_Store
 Thumbs.db
 
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Debug logs
+debug_logs/
+
 # Env
 .env
 .env.local
 kiro_creds.json
+
+# Notes
+kirogate-progress.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - REFRESH_TOKEN=${REFRESH_TOKEN:-}
 
       # 方式二: 挂载凭证文件 (见下方 volumes)
-      - KIRO_CREDS_FILE=${KIRO_CREDS_FILE:-}
+      - KIRO_CREDS_FILE=/app/credentials.json
 
       # 可选配置
       - PROFILE_ARN=${PROFILE_ARN:-}
@@ -65,9 +65,8 @@ services:
     volumes:
       # 持久化统计数据（使用命名卷，自动处理权限）
       - kirogate_data:/app/data
-      # 如果使用凭证文件，取消下面的注释
-      # - ~/.aws/sso/cache/kiro-auth-token.json:/app/credentials.json:ro
-      # 然后设置 KIRO_CREDS_FILE=/app/credentials.json
+      # IDC 凭证文件
+      - ./kiro_creds.json:/app/credentials.json:ro
 
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     container_name: kirogate
     restart: unless-stopped
     ports:
+      - "8833:8000"
       - "8000:8000"
     environment:
       # 必填: 代理服务器密码
@@ -55,6 +56,11 @@ services:
       # 静态资源代理配置
       - STATIC_ASSETS_PROXY_ENABLED=${STATIC_ASSETS_PROXY_ENABLED:-true}
       - STATIC_ASSETS_PROXY_BASE=${STATIC_ASSETS_PROXY_BASE:-https://proxy.jhun.edu.kg}
+
+      # 自动分片配置（长文档处理）
+      - AUTO_CHUNKING_ENABLED=${AUTO_CHUNKING_ENABLED:-true}
+      - AUTO_CHUNK_THRESHOLD=${AUTO_CHUNK_THRESHOLD:-150000}
+      - CHUNK_MAX_CHARS=${CHUNK_MAX_CHARS:-100000}
 
     volumes:
       # 持久化统计数据（使用命名卷，自动处理权限）

--- a/kiro_gateway/__init__.py
+++ b/kiro_gateway/__init__.py
@@ -106,6 +106,7 @@ from kiro_gateway.streaming import (
 # Exceptions
 from kiro_gateway.exceptions import (
     validation_exception_handler,
+    http_exception_handler,
     sanitize_validation_errors,
 )
 
@@ -162,5 +163,6 @@ __all__ = [
 
     # Exceptions
     "validation_exception_handler",
+    "http_exception_handler",
     "sanitize_validation_errors",
 ]

--- a/kiro_gateway/config.py
+++ b/kiro_gateway/config.py
@@ -158,6 +158,10 @@ class Settings(BaseSettings):
     # 超过此限制的描述将被移至 system prompt
     tool_description_max_length: int = Field(default=10000, alias="TOOL_DESCRIPTION_MAX_LENGTH")
 
+    # 输出限制警告设置
+    inject_output_limit_warning: bool = Field(default=False, alias="INJECT_OUTPUT_LIMIT_WARNING")
+    output_token_limit: int = Field(default=6000, alias="OUTPUT_TOKEN_LIMIT")
+
     # ==================================================================================================
     # 日志设置
     # ==================================================================================================
@@ -475,14 +479,14 @@ GITHUB_USER_URL: str = "https://api.github.com/user"
 # ==================================================================================================
 
 # 慢模型列表 - 这些模型需要更长的超时时间
-SLOW_MODELS: frozenset = frozenset({
+SLOW_MODELS: frozenset[str] = frozenset({
+    "claude-opus-4-6",
+    "claude-opus-4-6-thinking",
     "claude-opus-4-5",
     "claude-opus-4-5-20251101",
     "claude-3-opus",
     "claude-3-opus-20240229",
 })
-
-
 # ==================================================================================================
 # Kiro API URL Templates
 # ==================================================================================================
@@ -498,6 +502,11 @@ KIRO_Q_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
 
 # External model names (OpenAI compatible) -> Kiro internal ID
 MODEL_MAPPING: Dict[str, str] = {
+    # Claude Opus 4.6 - Top tier model
+    "claude-opus-4-6": "claude-opus-4.6",
+    "claude-opus-4-6-20250601": "claude-opus-4.6",
+    "claude-opus-4-6-thinking": "claude-opus-4.6",
+
     # Claude Opus 4.5 - Top tier model
     "claude-opus-4-5": "claude-opus-4.5",
     "claude-opus-4-5-20251101": "claude-opus-4.5",
@@ -506,6 +515,11 @@ MODEL_MAPPING: Dict[str, str] = {
     "claude-haiku-4-5": "claude-haiku-4.5",
     "claude-haiku-4-5-20251001": "claude-haiku-4.5",
     "claude-haiku-4.5": "claude-haiku-4.5",
+
+    # Claude Sonnet 4.6 - Enhanced model
+    "claude-sonnet-4-6": "claude-sonnet-4.6",
+    "claude-sonnet-4-6-20250601": "claude-sonnet-4.6",
+    "claude-sonnet-4-6-thinking": "claude-sonnet-4.6",
 
     # Claude Sonnet 4.5 - Enhanced model
     "claude-sonnet-4-5": "CLAUDE_SONNET_4_5_20250929_V1_0",
@@ -524,14 +538,33 @@ MODEL_MAPPING: Dict[str, str] = {
 
 # Available models list for /v1/models endpoint
 AVAILABLE_MODELS: List[str] = [
+    # Claude Opus 4.6
+    "claude-opus-4-6",
+    "claude-opus-4-6-20250601",
+    "claude-opus-4-6-thinking",
+
+    # Claude Opus 4.5
     "claude-opus-4-5",
     "claude-opus-4-5-20251101",
+
+    # Claude Haiku 4.5
     "claude-haiku-4-5",
     "claude-haiku-4-5-20251001",
+
+    # Claude Sonnet 4.6
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-6-20250601",
+    "claude-sonnet-4-6-thinking",
+
+    # Claude Sonnet 4.5
     "claude-sonnet-4-5",
     "claude-sonnet-4-5-20250929",
+
+    # Claude Sonnet 4
     "claude-sonnet-4",
     "claude-sonnet-4-20250514",
+
+    # Claude 3.7
     "claude-3-7-sonnet-20250219",
 ]
 

--- a/kiro_gateway/converters.py
+++ b/kiro_gateway/converters.py
@@ -269,6 +269,49 @@ def extract_images_from_content(content: Any) -> Tuple[List[Dict[str, Any]], int
     return images, len(images)
 
 
+def validate_and_fix_tool_pairs(messages):
+    """Validates and fixes toolUses/toolResults pairing issues.
+    
+    After OpenCode compaction, the history may contain:
+    - assistant messages with toolUses
+    - corresponding user messages (with toolResults) are deleted
+    
+    This causes Kiro API to return "Improperly formed request" error.
+    """
+    if not messages:
+        return messages
+    
+    valid_tool_use_ids = set()
+    for msg in messages:
+        if msg.role == "user":
+            content = msg.content
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "tool_result":
+                        tool_use_id = item.get("tool_use_id", "")
+                        if tool_use_id:
+                            valid_tool_use_ids.add(tool_use_id)
+    
+    if not valid_tool_use_ids:
+        return messages
+    
+    fixed_messages = []
+    for msg in messages:
+        if msg.role == "assistant" and msg.tool_calls:
+            original_count = len(msg.tool_calls)
+            filtered_calls = [
+                tc for tc in msg.tool_calls
+                if tc.id and tc.id in valid_tool_use_ids
+            ]
+            if len(filtered_calls) < original_count:
+                removed_count = original_count - len(filtered_calls)
+                print(f"Warning: Removed {removed_count} orphan tool_calls without matching toolResults")
+                msg.tool_calls = filtered_calls
+        fixed_messages.append(msg)
+    
+    return fixed_messages
+
+
 def merge_adjacent_messages(messages: List[ChatMessage]) -> List[ChatMessage]:
     """
     Объединяет соседние сообщения с одинаковой ролью и обрабатывает tool messages.
@@ -663,6 +706,8 @@ def build_kiro_payload(
 
     # Объединяем соседние сообщения с одинаковой ролью
     merged_messages = merge_adjacent_messages(non_system_messages)
+    # Validate and fix toolUses/toolResults pairs (fixes compaction issue)
+    merged_messages = validate_and_fix_tool_pairs(merged_messages)
     
     if not merged_messages:
         raise ValueError("没有可发送的消息")

--- a/kiro_gateway/converters.py
+++ b/kiro_gateway/converters.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from loguru import logger
 
-from kiro_gateway.config import get_internal_model_id, TOOL_DESCRIPTION_MAX_LENGTH
+from kiro_gateway.config import get_internal_model_id, TOOL_DESCRIPTION_MAX_LENGTH, AUTO_CHUNKING_ENABLED, AUTO_CHUNK_THRESHOLD
 from kiro_gateway.models import (
     ChatMessage,
     ChatCompletionRequest,
@@ -269,49 +269,201 @@ def extract_images_from_content(content: Any) -> Tuple[List[Dict[str, Any]], int
     return images, len(images)
 
 
+def _estimate_message_chars(msg) -> int:
+    """Estimate the character count of a message."""
+    total = 0
+    if hasattr(msg, 'content'):
+        content = msg.content
+    elif isinstance(msg, dict):
+        content = msg.get("content", "")
+    else:
+        return 0
+    
+    if isinstance(content, str):
+        total += len(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    total += len(block.get("text", ""))
+                elif block.get("type") == "tool_result":
+                    total += len(str(block.get("content", "")))
+            elif isinstance(block, str):
+                total += len(block)
+    
+    # Also count tool_calls
+    if hasattr(msg, 'tool_calls') and msg.tool_calls:
+        for tc in msg.tool_calls:
+            if isinstance(tc, dict):
+                total += len(str(tc.get("function", {}).get("arguments", "")))
+            elif hasattr(tc, 'function'):
+                total += len(str(getattr(tc.function, 'arguments', '')))
+    
+    return total
+
+
+def trim_history_to_fit(messages: list, max_chars: int = None) -> list:
+    """
+    Trim older history messages to fit within the Kiro API size limit.
+
+    Keeps the most recent messages and removes older ones from the beginning.
+    Ensures tool_use/tool_result pairs are kept together (removes both or neither).
+
+    Args:
+        messages: List of ChatMessage objects
+        max_chars: Maximum total character count. Uses AUTO_CHUNK_THRESHOLD if not specified.
+
+    Returns:
+        Trimmed list of messages
+    """
+    if not AUTO_CHUNKING_ENABLED:
+        return messages
+
+    if max_chars is None:
+        max_chars = AUTO_CHUNK_THRESHOLD
+
+    # Pre-compute per-message sizes to avoid O(n²) recalculation
+    sizes = [_estimate_message_chars(m) for m in messages]
+    total_chars = sum(sizes)
+
+    if total_chars <= max_chars:
+        return messages
+
+    logger.warning(f"Messages too long ({total_chars} chars > {max_chars} threshold), trimming history")
+
+    # Remove messages from the beginning until we fit, keeping at least the last message
+    trimmed = list(messages)
+    trimmed_sizes = list(sizes)
+
+    while len(trimmed) > 1 and total_chars > max_chars:
+        removed_size = trimmed_sizes.pop(0)
+        removed = trimmed.pop(0)
+        total_chars -= removed_size
+        logger.debug(f"Trimmed history message (role={removed.role}, ~{removed_size} chars)")
+
+        # If we removed an assistant message with tool_calls, also remove the following
+        # user message with tool_results to keep pairs consistent
+        if (removed.role == "assistant" and hasattr(removed, 'tool_calls') and removed.tool_calls
+                and trimmed and trimmed[0].role == "user"):
+            content = trimmed[0].content
+            has_tool_results = isinstance(content, list) and any(
+                isinstance(item, dict) and item.get("type") == "tool_result"
+                for item in content
+            )
+            if has_tool_results:
+                total_chars -= trimmed_sizes.pop(0)
+                trimmed.pop(0)
+                logger.debug("Also trimmed corresponding tool_results message")
+
+    removed_count = len(messages) - len(trimmed)
+    if removed_count > 0:
+        logger.info(f"Trimmed {removed_count} old messages to fit within size limit ({sum(sizes)} -> ~{total_chars} chars)")
+
+    return trimmed
+
+
+
 def validate_and_fix_tool_pairs(messages):
     """Validates and fixes toolUses/toolResults pairing issues.
-    
+
     After OpenCode compaction, the history may contain:
-    - assistant messages with toolUses
-    - corresponding user messages (with toolResults) are deleted
-    
+    - assistant messages with toolUses but no corresponding user messages with toolResults
+    - user messages with toolResults but no corresponding assistant toolUses
+
     This causes Kiro API to return "Improperly formed request" error.
+
+    Strategy:
+    1. Collect all tool_use IDs from assistant messages
+    2. Collect all tool_result IDs from user messages
+    3. Remove orphan tool_calls (no matching tool_result)
+    4. Remove orphan tool_results (no matching tool_use)
+    5. Clean up empty messages
     """
     if not messages:
         return messages
-    
-    valid_tool_use_ids = set()
+
+    def _get_tc_id(tc):
+        """Extract tool_call ID from either dict or object format."""
+        if isinstance(tc, dict):
+            return tc.get('id')
+        return getattr(tc, 'id', None)
+
+    # Pass 1: Collect all tool_use IDs and tool_result IDs
+    all_tool_use_ids = set()
+    all_tool_result_ids = set()
+
     for msg in messages:
-        if msg.role == "user":
-            content = msg.content
-            if isinstance(content, list):
-                for item in content:
-                    if isinstance(item, dict) and item.get("type") == "tool_result":
-                        tool_use_id = item.get("tool_use_id", "")
-                        if tool_use_id:
-                            valid_tool_use_ids.add(tool_use_id)
-    
-    if not valid_tool_use_ids:
-        return messages
-    
+        if msg.role == "assistant" and msg.tool_calls:
+            for tc in msg.tool_calls:
+                tc_id = _get_tc_id(tc)
+                if tc_id:
+                    all_tool_use_ids.add(tc_id)
+        elif msg.role == "user" and isinstance(msg.content, list):
+            for item in msg.content:
+                if isinstance(item, dict) and item.get("type") == "tool_result":
+                    tool_use_id = item.get("tool_use_id", "")
+                    if tool_use_id:
+                        all_tool_result_ids.add(tool_use_id)
+        elif msg.role == "tool" and msg.tool_call_id:
+            all_tool_result_ids.add(msg.tool_call_id)
+
+    matched_ids = all_tool_use_ids & all_tool_result_ids
+
+    # Pass 2: Fix messages — keep only matched pairs
     fixed_messages = []
     for msg in messages:
         if msg.role == "assistant" and msg.tool_calls:
             original_count = len(msg.tool_calls)
-            # Handle both object and dict formats for tool_calls
-            filtered_calls = []
-            for tc in msg.tool_calls:
-                tc_id = tc.id if hasattr(tc, 'id') else tc.get('id') if isinstance(tc, dict) else None
-                if tc_id and tc_id in valid_tool_use_ids:
-                    filtered_calls.append(tc)
-            if len(filtered_calls) < original_count:
-                removed_count = original_count - len(filtered_calls)
-                print(f"Warning: Removed {removed_count} orphan tool_calls without matching toolResults")
-                msg.tool_calls = filtered_calls
-        fixed_messages.append(msg)
-    
+            filtered_calls = [tc for tc in msg.tool_calls
+                              if not _get_tc_id(tc) or _get_tc_id(tc) in matched_ids]
+
+            removed = original_count - len(filtered_calls)
+            if removed:
+                logger.warning(f"Removed {removed} orphan tool_calls without matching toolResults")
+
+            msg.tool_calls = filtered_calls or None
+
+            content_text = extract_text_content(msg.content) if msg.content else ""
+            if not msg.tool_calls and not content_text.strip():
+                logger.warning("Removing empty assistant message (all tool_calls were orphans)")
+                continue
+
+            fixed_messages.append(msg)
+
+        elif msg.role == "user" and isinstance(msg.content, list):
+            filtered_content = []
+            removed_results = 0
+
+            for item in msg.content:
+                if isinstance(item, dict) and item.get("type") == "tool_result":
+                    if item.get("tool_use_id", "") in matched_ids:
+                        filtered_content.append(item)
+                    else:
+                        removed_results += 1
+                else:
+                    filtered_content.append(item)
+
+            if removed_results:
+                logger.warning(f"Removed {removed_results} orphan tool_results without matching toolUse")
+
+            if not filtered_content:
+                logger.warning("Removing empty user message (all tool_results were orphans)")
+                continue
+
+            msg.content = filtered_content
+            fixed_messages.append(msg)
+
+        elif msg.role == "tool":
+            if msg.tool_call_id and msg.tool_call_id not in matched_ids:
+                logger.warning(f"Removing orphan tool message for tool_call_id={msg.tool_call_id}")
+                continue
+            fixed_messages.append(msg)
+
+        else:
+            fixed_messages.append(msg)
+
     return fixed_messages
+
 
 
 def merge_adjacent_messages(messages: List[ChatMessage]) -> List[ChatMessage]:
@@ -418,6 +570,7 @@ def merge_adjacent_messages(messages: List[ChatMessage]) -> List[ChatMessage]:
     return merged
 
 
+
 def build_kiro_history(messages: List[ChatMessage], model_id: str) -> List[Dict[str, Any]]:
     """
     Строит массив history для Kiro API из OpenAI messages.
@@ -434,21 +587,13 @@ def build_kiro_history(messages: List[ChatMessage], model_id: str) -> List[Dict[
 
     Returns:
         Список словарей для поля history в Kiro API
-
-    Example:
-        >>> msgs = [ChatMessage(role="user", content="Hello")]
-        >>> history = build_kiro_history(msgs, "claude-sonnet-4")
-        >>> history[0]["userInputMessage"]["content"]
-        'Hello'
     """
     history = []
 
     for msg in messages:
         if msg.role == "user":
-            # 提取文本内容
             content = extract_text_content(msg.content)
 
-            # 检查历史消息中是否有图片，用占位符替代
             _, image_count = extract_images_from_content(msg.content)
             if image_count > 0:
                 image_placeholder = f"\n[此消息包含 {image_count} 张图片，已在历史记录中省略]"
@@ -456,12 +601,11 @@ def build_kiro_history(messages: List[ChatMessage], model_id: str) -> List[Dict[
                 logger.debug(f"Replaced {image_count} image(s) with placeholder in history message")
 
             user_input = {
-                "content": content,
+                "content": content or "(empty)",
                 "modelId": model_id,
                 "origin": "AI_EDITOR",
             }
 
-            # Обработка tool_results (ответы на tool calls)
             tool_results = _extract_tool_results(msg.content)
             if tool_results:
                 user_input["userInputMessageContext"] = {"toolResults": tool_results}
@@ -471,9 +615,8 @@ def build_kiro_history(messages: List[ChatMessage], model_id: str) -> List[Dict[
         elif msg.role == "assistant":
             content = extract_text_content(msg.content)
 
-            assistant_response = {"content": content}
+            assistant_response = {"content": content or "(empty)"}
 
-            # Обработка tool_calls
             tool_uses = _extract_tool_uses(msg)
             if tool_uses:
                 assistant_response["toolUses"] = tool_uses
@@ -481,10 +624,45 @@ def build_kiro_history(messages: List[ChatMessage], model_id: str) -> List[Dict[
             history.append({"assistantResponseMessage": assistant_response})
 
         elif msg.role == "system":
-            # System prompt обрабатывается отдельно в build_kiro_payload
             pass
 
+    # Safety: ensure strict alternation of user/assistant messages
+    # Kiro API requires this pattern. Remove consecutive same-type entries.
+    if len(history) > 1:
+        cleaned = [history[0]]
+        for entry in history[1:]:
+            prev_type = "user" if "userInputMessage" in cleaned[-1] else "assistant"
+            curr_type = "user" if "userInputMessage" in entry else "assistant"
+            if prev_type == curr_type:
+                # Merge into previous entry
+                if curr_type == "user":
+                    prev_content = cleaned[-1]["userInputMessage"]["content"]
+                    curr_content = entry["userInputMessage"]["content"]
+                    cleaned[-1]["userInputMessage"]["content"] = f"{prev_content}\n{curr_content}"
+                    # Merge tool_results
+                    prev_ctx = cleaned[-1]["userInputMessage"].get("userInputMessageContext", {})
+                    curr_ctx = entry["userInputMessage"].get("userInputMessageContext", {})
+                    if curr_ctx.get("toolResults"):
+                        prev_results = prev_ctx.get("toolResults", [])
+                        prev_results.extend(curr_ctx["toolResults"])
+                        cleaned[-1]["userInputMessage"]["userInputMessageContext"] = {"toolResults": prev_results}
+                else:
+                    prev_content = cleaned[-1]["assistantResponseMessage"]["content"]
+                    curr_content = entry["assistantResponseMessage"]["content"]
+                    cleaned[-1]["assistantResponseMessage"]["content"] = f"{prev_content}\n{curr_content}"
+                    # Merge toolUses
+                    prev_uses = cleaned[-1]["assistantResponseMessage"].get("toolUses", [])
+                    curr_uses = entry["assistantResponseMessage"].get("toolUses", [])
+                    if curr_uses:
+                        prev_uses.extend(curr_uses)
+                        cleaned[-1]["assistantResponseMessage"]["toolUses"] = prev_uses
+                logger.debug(f"Merged consecutive {curr_type} history entries")
+            else:
+                cleaned.append(entry)
+        history = cleaned
+
     return history
+
 
 
 def _extract_tool_results(content: Any) -> List[Dict[str, Any]]:
@@ -596,28 +774,59 @@ def process_tools_with_long_descriptions(
     return processed_tools if processed_tools else None, tool_documentation
 
 
+
 def _extract_tool_uses(msg: ChatMessage) -> List[Dict[str, Any]]:
     """
     Извлекает tool uses из сообщения assistant.
-    
+
     Args:
         msg: Сообщение assistant
-    
+
     Returns:
         Список tool uses в формате Kiro
     """
     tool_uses = []
-    
+
     # Из поля tool_calls
     if msg.tool_calls:
         for tc in msg.tool_calls:
-            if isinstance(tc, dict):
+            try:
+                if isinstance(tc, dict):
+                    func = tc.get("function", {})
+                    name = func.get("name", "")
+                    arguments = func.get("arguments", "{}")
+                    tc_id = tc.get("id", "")
+                else:
+                    # Object format (e.g., from Pydantic model)
+                    func = getattr(tc, 'function', None)
+                    if func:
+                        name = getattr(func, 'name', '') or ''
+                        arguments = getattr(func, 'arguments', '{}') or '{}'
+                    else:
+                        name = ""
+                        arguments = "{}"
+                    tc_id = getattr(tc, 'id', '') or ''
+
+                # Parse arguments safely
+                if isinstance(arguments, str):
+                    try:
+                        parsed_input = json.loads(arguments)
+                    except (json.JSONDecodeError, TypeError):
+                        parsed_input = {"raw": arguments}
+                elif isinstance(arguments, dict):
+                    parsed_input = arguments
+                else:
+                    parsed_input = {}
+
                 tool_uses.append({
-                    "name": tc.get("function", {}).get("name", ""),
-                    "input": json.loads(tc.get("function", {}).get("arguments", "{}")),
-                    "toolUseId": tc.get("id", "")
+                    "name": name,
+                    "input": parsed_input,
+                    "toolUseId": tc_id
                 })
-    
+            except Exception as e:
+                logger.warning(f"Failed to extract tool_use: {e}, skipping")
+                continue
+
     # Из content (если там есть tool_use)
     if isinstance(msg.content, list):
         for item in msg.content:
@@ -627,8 +836,9 @@ def _extract_tool_uses(msg: ChatMessage) -> List[Dict[str, Any]]:
                     "input": item.get("input", {}),
                     "toolUseId": item.get("id", "")
                 })
-    
+
     return tool_uses
+
 
 
 def _extract_system_and_tool_docs(
@@ -706,16 +916,23 @@ def build_kiro_payload(
     # 注入 thinking 标签到 system prompt（如果启用）
     system_prompt = inject_thinking_hint(system_prompt, thinking_config)
 
+    # Validate and fix toolUses/toolResults pairs BEFORE merging
+    # (fixes compaction issue where OpenCode removes toolResults)
+    validated_messages = validate_and_fix_tool_pairs(non_system_messages)
+    # Trim history if too long to avoid CONTENT_LENGTH_EXCEEDS_THRESHOLD
+    validated_messages = trim_history_to_fit(validated_messages)
     # Объединяем соседние сообщения с одинаковой ролью
-    merged_messages = merge_adjacent_messages(non_system_messages)
-    # Validate and fix toolUses/toolResults pairs (fixes compaction issue)
-    merged_messages = validate_and_fix_tool_pairs(merged_messages)
+    merged_messages = merge_adjacent_messages(validated_messages)
     
     if not merged_messages:
         raise ValueError("没有可发送的消息")
     
     # Получаем внутренний ID модели
     model_id = get_internal_model_id(request_data.model)
+    
+    # Split last message if it contains tool_results mixed with text.
+    # Kiro API expects tool_results in history (paired with toolUse), not in currentMessage.
+    merged_messages = _split_last_message_tool_results(merged_messages)
     
     # Строим историю (все сообщения кроме последнего)
     history_messages = merged_messages[:-1] if len(merged_messages) > 1 else []
@@ -793,6 +1010,62 @@ def build_kiro_payload(
         payload["profileArn"] = profile_arn
     
     return payload
+
+def _split_last_message_tool_results(messages: List[ChatMessage]) -> List[ChatMessage]:
+    """
+    Split the last user message if it contains both tool_results and text.
+
+    Kiro API expects tool_results in history (paired with their toolUse),
+    not in currentMessage. If tool_results end up in currentMessage.toolResults,
+    the API sees orphan toolUse in history → "Improperly formed request".
+
+    Args:
+        messages: Merged message list
+
+    Returns:
+        Messages with last message split if needed
+    """
+    if not messages:
+        return messages
+
+    last_msg = messages[-1]
+    if last_msg.role != "user" or not isinstance(last_msg.content, list):
+        return messages
+
+    tool_result_items = [item for item in last_msg.content
+                         if isinstance(item, dict) and item.get("type") == "tool_result"]
+    non_tool_items = [item for item in last_msg.content
+                      if not (isinstance(item, dict) and item.get("type") == "tool_result")]
+
+    if not tool_result_items:
+        return messages
+
+    # Move tool_results to a separate history message
+    tool_results_msg = ChatMessage(role="user", content=tool_result_items)
+    base = messages[:-1] + [tool_results_msg]
+
+    if non_tool_items:
+        # Extract text from remaining items
+        logger.info(f"Splitting last message: {len(tool_result_items)} tool_results → history, "
+                     f"{len(non_tool_items)} text items → currentMessage")
+        if (len(non_tool_items) == 1 and isinstance(non_tool_items[0], dict)
+                and non_tool_items[0].get("type") == "text"):
+            text_content = non_tool_items[0].get("text", "")
+        else:
+            text_content = " ".join(
+                item.get("text", "") if isinstance(item, dict) else str(item)
+                for item in non_tool_items
+            ).strip()
+        base.append(ChatMessage(role="user", content=text_content or "Continue"))
+    else:
+        # Only tool_results, no text
+        logger.info(f"Last message has only tool_results ({len(tool_result_items)}), "
+                     "moving to history and adding placeholder currentMessage")
+        base.append(ChatMessage(role="user", content="Please process the tool results."))
+
+    return base
+
+
 
 
 def _build_user_input_context(

--- a/kiro_gateway/converters.py
+++ b/kiro_gateway/converters.py
@@ -299,10 +299,12 @@ def validate_and_fix_tool_pairs(messages):
     for msg in messages:
         if msg.role == "assistant" and msg.tool_calls:
             original_count = len(msg.tool_calls)
-            filtered_calls = [
-                tc for tc in msg.tool_calls
-                if tc.id and tc.id in valid_tool_use_ids
-            ]
+            # Handle both object and dict formats for tool_calls
+            filtered_calls = []
+            for tc in msg.tool_calls:
+                tc_id = tc.id if hasattr(tc, 'id') else tc.get('id') if isinstance(tc, dict) else None
+                if tc_id and tc_id in valid_tool_use_ids:
+                    filtered_calls.append(tc)
             if len(filtered_calls) < original_count:
                 removed_count = original_count - len(filtered_calls)
                 print(f"Warning: Removed {removed_count} orphan tool_calls without matching toolResults")

--- a/kiro_gateway/exceptions.py
+++ b/kiro_gateway/exceptions.py
@@ -71,6 +71,8 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     Логирует детали ошибки и возвращает информативный ответ.
     Корректно обрабатывает bytes объекты в ошибках, преобразуя их в строки.
     
+    For /v1/ API endpoints, returns OpenAI-compatible error format.
+    
     Args:
         request: FastAPI Request объект
         exc: Исключение валидации от Pydantic
@@ -87,7 +89,88 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     logger.error(f"Validation error (422): {sanitized_errors}")
     logger.error(f"Request body: {body_str[:500]}...")
     
+    # For /v1/ API endpoints, return OpenAI-compatible error format
+    # OpenCode (@ai-sdk/openai-compatible) and OpenClaw (openai-completions)
+    # both expect {"error": {"message": "...", "type": "...", "code": ...}}
+    path = request.url.path
+    if path.startswith("/v1/"):
+        # Build a human-readable error message from validation errors
+        error_parts = []
+        for err in sanitized_errors:
+            loc = " -> ".join(str(l) for l in err.get("loc", []))
+            msg = err.get("msg", "unknown error")
+            error_parts.append(f"{loc}: {msg}" if loc else msg)
+        error_message = "; ".join(error_parts) if error_parts else "Request validation failed"
+        
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": {
+                    "message": error_message,
+                    "type": "invalid_request_error",
+                    "code": "validation_error"
+                }
+            },
+        )
+    
     return JSONResponse(
         status_code=422,
         content={"detail": sanitized_errors, "body": body_str[:500]},
+    )
+
+
+async def http_exception_handler(request: Request, exc) -> JSONResponse:
+    """
+    Global HTTPException handler that returns OpenAI-compatible error format
+    for /v1/ API endpoints.
+    
+    OpenCode (@ai-sdk/openai-compatible) and OpenClaw (openai-completions api)
+    both expect error responses in the format:
+    {"error": {"message": "...", "type": "...", "code": ...}}
+    
+    FastAPI's default HTTPException returns {"detail": "..."} which these
+    SDKs cannot parse correctly.
+    
+    Args:
+        request: FastAPI Request
+        exc: HTTPException
+    
+    Returns:
+        JSONResponse with OpenAI-compatible error format for API endpoints,
+        or default format for non-API endpoints
+    """
+    path = request.url.path
+    status_code = getattr(exc, 'status_code', 500)
+    detail = getattr(exc, 'detail', 'Internal server error')
+    
+    if path.startswith("/v1/"):
+        # Map HTTP status codes to OpenAI error types
+        error_type_map = {
+            400: "invalid_request_error",
+            401: "authentication_error",
+            403: "permission_error",
+            404: "not_found_error",
+            422: "invalid_request_error",
+            429: "rate_limit_error",
+            500: "server_error",
+            502: "server_error",
+            503: "server_error",
+        }
+        error_type = error_type_map.get(status_code, "api_error")
+        
+        return JSONResponse(
+            status_code=status_code,
+            content={
+                "error": {
+                    "message": str(detail),
+                    "type": error_type,
+                    "code": status_code
+                }
+            },
+        )
+    
+    # For non-API endpoints, use default format
+    return JSONResponse(
+        status_code=status_code,
+        content={"detail": str(detail)},
     )

--- a/kiro_gateway/health_checker.py
+++ b/kiro_gateway/health_checker.py
@@ -60,14 +60,26 @@ class TokenHealthChecker:
 
     async def check_all_tokens(self) -> dict:
         """
-        Check all active tokens.
+        Check all active and invalid tokens.
 
         Returns:
             Summary of check results
         """
-        tokens = user_db.get_all_active_tokens()
+        # Check both active and invalid tokens so previously-failed tokens can recover
+        active_tokens = user_db.get_all_active_tokens()
+        invalid_tokens_dict = user_db.get_all_tokens_with_users(status="invalid")
+        invalid_tokens = [t for t in invalid_tokens_dict] if invalid_tokens_dict else []
+        
+        # Convert dict to token-like objects for invalid tokens
+        class InvalidToken:
+            def __init__(self, d):
+                self.id = d.get("id")
+                self.status = "invalid"
+        invalid_tokens = [InvalidToken(t) for t in invalid_tokens]
+        
+        tokens = active_tokens + invalid_tokens
         if not tokens:
-            logger.debug("No active tokens to check")
+            logger.debug("No tokens to check")
             return {"checked": 0, "valid": 0, "invalid": 0}
 
         logger.info(f"Starting health check for {len(tokens)} tokens")
@@ -80,11 +92,57 @@ class TokenHealthChecker:
                 is_valid = await self.check_token(token.id)
                 if is_valid:
                     valid_count += 1
+                    if token.status != "active":
+                        user_db.set_token_status(token.id, "active")
+                        logger.info(f"Token {token.id} recovered, marked as active")
                 else:
                     invalid_count += 1
-                    # Mark token as invalid if it fails
-                    user_db.set_token_status(token.id, "invalid")
-                    logger.warning(f"Token {token.id} marked as invalid")
+                    if token.status != "invalid":
+                        user_db.set_token_status(token.id, "invalid")
+                        logger.warning(f"Token {token.id} marked as invalid")
+            except Exception as e:
+                logger.error(f"Failed to check token {token.id}: {e}")
+                invalid_count += 1
+
+            # Small delay between checks to avoid rate limiting
+            await asyncio.sleep(1)
+
+        logger.info(f"Health check complete: {valid_count} valid, {invalid_count} invalid")
+        return {
+            "checked": len(tokens),
+            "valid": valid_count,
+            "invalid": invalid_count
+        }
+        """
+        Check all active and invalid tokens.
+
+        Returns:
+            Summary of check results
+        """
+        # Check both active and invalid tokens so previously-failed tokens can recover
+        tokens = user_db.get_all_active_tokens() + user_db.get_tokens_by_status("invalid")
+        if not tokens:
+            logger.debug("No tokens to check")
+            return {"checked": 0, "valid": 0, "invalid": 0}
+
+        logger.info(f"Starting health check for {len(tokens)} tokens")
+
+        valid_count = 0
+        invalid_count = 0
+
+        for token in tokens:
+            try:
+                is_valid = await self.check_token(token.id)
+                if is_valid:
+                    valid_count += 1
+                    if token.status != "active":
+                        user_db.set_token_status(token.id, "active")
+                        logger.info(f"Token {token.id} recovered, marked as active")
+                else:
+                    invalid_count += 1
+                    if token.status != "invalid":
+                        user_db.set_token_status(token.id, "invalid")
+                        logger.warning(f"Token {token.id} marked as invalid")
             except Exception as e:
                 logger.error(f"Failed to check token {token.id}: {e}")
                 invalid_count += 1
@@ -100,6 +158,47 @@ class TokenHealthChecker:
         }
 
     async def check_token(self, token_id: int) -> bool:
+        """
+        Check a single token's validity.
+
+        Args:
+            token_id: Token ID to check
+
+        Returns:
+            True if token is valid, False otherwise
+        """
+        # Get full token credentials (including client_id/client_secret for IDC tokens)
+        creds = user_db.get_token_credentials(token_id)
+        if not creds or not creds.get("refresh_token"):
+            user_db.record_health_check(token_id, False, "Failed to get token credentials")
+            return False
+
+        refresh_token = creds["refresh_token"]
+        client_id = creds.get("client_id")
+        client_secret = creds.get("client_secret")
+
+        # Try to get access token
+        try:
+            manager = KiroAuthManager(
+                refresh_token=refresh_token,
+                region=settings.region,
+                profile_arn=settings.profile_arn,
+                client_id=client_id,
+                client_secret=client_secret
+            )
+            access_token = await manager.get_access_token()
+
+            if access_token:
+                user_db.record_health_check(token_id, True)
+                return True
+            else:
+                user_db.record_health_check(token_id, False, "No access token returned")
+                return False
+
+        except Exception as e:
+            error_msg = str(e)[:200]  # Truncate long error messages
+            user_db.record_health_check(token_id, False, error_msg)
+            return False
         """
         Check a single token's validity.
 

--- a/kiro_gateway/request_handler.py
+++ b/kiro_gateway/request_handler.py
@@ -35,7 +35,7 @@ from loguru import logger
 from kiro_gateway.auth import KiroAuthManager
 from kiro_gateway.cache import ModelInfoCache
 from kiro_gateway.converters import build_kiro_payload, convert_anthropic_to_openai_request, is_thinking_enabled
-from kiro_gateway.config import settings
+from kiro_gateway.config import settings, AUTO_CHUNKING_ENABLED, AUTO_CHUNK_THRESHOLD
 from kiro_gateway.http_client import KiroHttpClient
 from kiro_gateway.models import (
     ChatCompletionRequest,
@@ -48,7 +48,6 @@ from kiro_gateway.streaming import (
     collect_anthropic_response,
 )
 from kiro_gateway.utils import generate_conversation_id, get_kiro_headers
-from kiro_gateway.config import settings, AUTO_CHUNKING_ENABLED, AUTO_CHUNK_THRESHOLD
 from kiro_gateway.metrics import metrics
 
 
@@ -65,6 +64,50 @@ try:
     from kiro_gateway.debug_logger import debug_logger
 except ImportError:
     debug_logger = None
+
+
+def _maybe_build_retry_payload(error_text, kiro_payload, openai_request,
+                                conversation_id, auth_manager, thinking_config):
+    """
+    Inspect a Kiro API error and return a modified payload for retry, or None if no retry.
+
+    Handles two known error patterns:
+    - CONTENT_LENGTH_EXCEEDS_THRESHOLD: aggressively trim history to 1/3
+    - Improperly formed request: strip history and orphan toolResults entirely
+    """
+    if "CONTENT_LENGTH_EXCEEDS_THRESHOLD" in error_text:
+        logger.warning("CONTENT_LENGTH_EXCEEDS_THRESHOLD — retrying with aggressively trimmed history")
+        try:
+            payload = build_kiro_payload(
+                openai_request, conversation_id,
+                auth_manager.profile_arn or "",
+                thinking_config=thinking_config
+            )
+        except ValueError:
+            return None
+        history = payload.get("conversationState", {}).get("history")
+        if history and len(history) > 4:
+            keep = max(4, len(history) // 3)
+            payload["conversationState"]["history"] = history[-keep:]
+            logger.info(f"Aggressively trimmed history from {len(history)} to {keep} entries")
+        return payload
+
+    if "Improperly formed request" in error_text:
+        logger.warning("Improperly formed request — retrying without history")
+        conv_state = kiro_payload.get("conversationState", {})
+        conv_state.pop("history", None)
+        logger.info("Removed all history from payload for retry")
+        # Remove orphan toolResults from currentMessage (no history = no matching toolUse)
+        current_msg = conv_state.get("currentMessage", {}).get("userInputMessage", {})
+        ctx = current_msg.get("userInputMessageContext", {})
+        if "toolResults" in ctx:
+            del ctx["toolResults"]
+            logger.info("Removed orphan toolResults from currentMessage (no history)")
+            if not ctx and "userInputMessageContext" in current_msg:
+                del current_msg["userInputMessageContext"]
+        return kiro_payload
+
+    return None
 
 
 class RequestHandler:
@@ -464,6 +507,14 @@ class RequestHandler:
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
+        # Safety check: estimate payload size and log warning
+        payload_json = json.dumps(kiro_payload, ensure_ascii=False)
+        payload_size = len(payload_json)
+        logger.info(f"Kiro payload size: {payload_size} chars")
+        if payload_size > AUTO_CHUNK_THRESHOLD:
+            logger.warning(f"Payload size ({payload_size}) exceeds threshold ({AUTO_CHUNK_THRESHOLD}), "
+                          "history was already trimmed but payload is still large")
+
         # 记录 Kiro 请求
         RequestHandler.log_kiro_request(kiro_payload)
 
@@ -480,6 +531,26 @@ class RequestHandler:
                 stream=True,
                 model=request_data.model
             )
+
+            # Retry on known Kiro API errors
+            if response.status_code != 200:
+                error_text = ""
+                try:
+                    error_text = (await response.aread()).decode('utf-8', errors='replace')
+                except Exception:
+                    pass
+
+                retry_payload = _maybe_build_retry_payload(error_text, kiro_payload, openai_request,
+                                                           conversation_id, auth_manager, thinking_config)
+                if retry_payload is not None:
+                    try:
+                        await response.aclose()
+                    except Exception:
+                        pass
+                    kiro_payload = retry_payload
+                    response = await http_client.request_with_retry(
+                        "POST", url, kiro_payload, stream=True, model=request_data.model
+                    )
 
             if response.status_code != 200:
                 duration_ms = (time.time() - start_time) * 1000

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ from kiro_gateway.config import (
 from kiro_gateway.auth import KiroAuthManager
 from kiro_gateway.cache import ModelInfoCache
 from kiro_gateway.routes import router, limiter, rate_limit_handler
-from kiro_gateway.exceptions import validation_exception_handler
+from kiro_gateway.exceptions import validation_exception_handler, http_exception_handler
 from kiro_gateway.middleware import RequestTrackingMiddleware, MetricsMiddleware, SiteGuardMiddleware
 from kiro_gateway.http_client import close_global_http_client
 
@@ -316,6 +316,10 @@ app.add_exception_handler(RateLimitExceeded, rate_limit_handler)
 
 # 注册验证错误处理器
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
+
+# 注册 HTTPException 处理器 (OpenAI 兼容错误格式)
+from fastapi import HTTPException as _HTTPException
+app.add_exception_handler(_HTTPException, http_exception_handler)
 
 
 # 404 页面处理器


### PR DESCRIPTION
## Summary

本 PR 包含 5 大改动：健康检查器 IDC 修复、工具配对验证修复、OpenAI 兼容错误格式、请求重试机制、代码优化重构。

---

## Changes

### 1. Health Checker IDC Token Support (`health_checker.py`)
- 健康检查器传递 `client_id` 和 `client_secret` 以支持 IDC token 刷新
- 同时检查 active 和 invalid 状态的 token
- 自动恢复被误标为 invalid 的有效 token

### 2. Tool Pairs 验证修复 (`converters.py`)

**问题**: OpenCode 执行 compaction（上下文裁剪）后，历史消息中可能出现：
- assistant 消息有 `toolUses` 但对应的 user `toolResults` 被删除
- user 消息有 `toolResults` 但对应的 assistant `toolUses` 被删除

Kiro API 要求每个 toolUse 必须有对应的 toolResult，否则返回 `"Improperly formed request"`。

**修复**:
- `validate_and_fix_tool_pairs()` — 双向验证，移除所有孤立的 tool_calls 和 tool_results
- `_split_last_message_tool_results()` — 当最后一条消息同时包含 tool_results 和文本时，将 tool_results 拆分到历史中（与 toolUse 配对），文本作为 currentMessage
- `trim_history_to_fit()` — 历史消息过长时自动裁剪，保持 tool_use/tool_result 配对完整
- `build_kiro_payload()` 调用顺序：validate → trim → merge → split

### 3. OpenAI 兼容错误格式 (`exceptions.py`, `main.py`)

**问题**: FastAPI 默认的 `HTTPException` 返回 `{"detail": "..."}` 格式，但 OpenCode (`@ai-sdk/openai-compatible`) 和 OpenClaw (`openai-completions` 模式) 都期望 OpenAI 标准格式：
```json
{"error": {"message": "...", "type": "...", "code": ...}}
```

**修复**:
- 新增 `http_exception_handler()` — 对所有 `/v1/` 端点的错误返回 OpenAI 格式
- HTTP 状态码映射：400→invalid_request_error, 401→authentication_error, 429→rate_limit_error 等
- `validation_exception_handler()` 也对 `/v1/` 端点返回 OpenAI 格式
- 在 `main.py` 注册全局异常处理器

### 4. 请求重试机制 (`request_handler.py`)

- `CONTENT_LENGTH_EXCEEDS_THRESHOLD` 错误：自动将历史裁剪到 1/3 后重试
- `Improperly formed request` 错误：移除全部历史和孤立 toolResults 后重试
- 重试逻辑提取为 `_maybe_build_retry_payload()` 函数

### 5. 代码优化重构

**converters.py**:
- `trim_history_to_fit()`: 从 O(n²) 优化到 O(n)，预计算 sizes 数组做增量减法
- `validate_and_fix_tool_pairs()`: 提取 `_get_tc_id()` 消除重复的 ID 提取逻辑，合并两个收集 pass
- `build_kiro_payload()`: 30+ 行的 split 逻辑提取为独立的 `_split_last_message_tool_results()` 函数

**request_handler.py**:
- 两个重试分支提取为 `_maybe_build_retry_payload()` 函数
- 修复 `from kiro_gateway.config import settings` 重复导入
- 删除定义但未使用的 `reduced_threshold` 变量

### 6. 其他
- 新增 Claude 4.6 模型支持（opus/sonnet 及 thinking 变体）
- Docker Compose 配置凭证文件挂载
- `.gitignore` 添加 `kiro_creds.json`

---

## Files Changed

| File | Changes |
|------|---------|
| `kiro_gateway/converters.py` | +344 -24 — 工具配对验证、历史裁剪、split 逻辑、O(n) 优化 |
| `kiro_gateway/health_checker.py` | +105 -6 — IDC token 健康检查修复 |
| `kiro_gateway/exceptions.py` | +83 — OpenAI 兼容错误格式处理器 |
| `kiro_gateway/request_handler.py` | +73 -2 — 重试逻辑提取、重复导入修复 |
| `kiro_gateway/config.py` | +36 -3 — 新模型、新配置项 |
| `docker-compose.yml` | +9 -4 — 凭证文件挂载 |
| `main.py` | +5 -1 — 注册异常处理器 |
| `kiro_gateway/__init__.py` | +2 — 导出新函数 |
| `.gitignore` | +1 — 忽略凭证文件 |

---

## Testing

### 基础请求测试
```bash
curl -X POST http://localhost:8833/v1/chat/completions \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Hi"}],"max_tokens":50}'
```

### Tool Calls 测试（验证 tool pairs 修复）
```bash
curl -X POST http://localhost:8833/v1/chat/completions \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model":"claude-haiku-4-5",
    "messages":[
      {"role":"user","content":"What is 2+2?"},
      {"role":"assistant","content":"Let me calculate.","tool_calls":[{"id":"call_1","type":"function","function":{"name":"calc","arguments":"{\"expr\":\"2+2\"}"}}]},
      {"role":"tool","tool_call_id":"call_1","content":"4"},
      {"role":"user","content":"Thanks! Now 3+3?"}
    ],
    "max_tokens":50
  }'
```

### 错误格式测试（验证 OpenAI 兼容）
```bash
curl -s http://localhost:8833/v1/chat/completions \
  -H "Authorization: Bearer wrong-key" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"}]}'
# Expected: {"error":{"message":"...","type":"authentication_error","code":401}}
```

### Anthropic 格式测试
```bash
curl -X POST http://localhost:8833/v1/messages \
  -H "x-api-key: YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{"model":"claude-sonnet-4-6","max_tokens":50,"messages":[{"role":"user","content":"Hi"}]}'
```

所有测试均已通过验证。